### PR TITLE
Consistant naming of the tool to redis-cluster-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To build redis-cluster-tool:
 
 ## Help
 
-    Usage: redis_cluster_tool [-?hVd] [-v verbosity level] [-o output file]
+    Usage: redis-cluster-tool [-?hVd] [-v verbosity level] [-o output file]
                     [-c conf file] [-a addr] [-i interval]
                     [-p pid file]
     
@@ -55,7 +55,7 @@ The command must be covered by double quotation marks, if there were more than o
 
 **Get the cluster state:**
 
-    $redis_cluster_tool -a 127.0.0.1:34501 -C cluster_state
+    $redis-cluster-tool -a 127.0.0.1:34501 -C cluster_state
     node[127.0.0.1:34504] cluster_state is ok 
     node[127.0.0.1:34501] cluster_state is ok 
     node[127.0.0.1:34502] cluster_state is ok 
@@ -65,7 +65,7 @@ The command must be covered by double quotation marks, if there were more than o
     
 **Get the cluster used memory:**
 
-    $redis_cluster_tool -a 127.0.0.1:34501 -C cluster_used_memory
+    $redis-cluster-tool -a 127.0.0.1:34501 -C cluster_used_memory
     node[127.0.0.1:34504] used 195 M	25%
     node[127.0.0.1:34501] used 195 M	25%
     node[127.0.0.1:34502] used 195 M	25%

--- a/rct.c
+++ b/rct.c
@@ -139,7 +139,7 @@ int main(int argc,char *argv[])
     }
     
     if (nci.show_version) {
-        log_stderr("This is redis_cluster_tool-%s" CRLF, RCT_VERSION_STRING);
+        log_stderr("This is redis-cluster-tool-%s" CRLF, RCT_VERSION_STRING);
         if (nci.show_help) {
             rct_show_usage();
         }

--- a/rct_option.c
+++ b/rct_option.c
@@ -34,7 +34,7 @@ void
 rct_show_usage(void)
 {
     log_stderr(
-        "Usage: redis_cluster_tool [-?hVd] [-v verbosity level] [-o output file]" CRLF
+        "Usage: redis-cluster-tool [-?hVd] [-v verbosity level] [-o output file]" CRLF
         "                  [-c conf file] [-a addr] [-i interval]" CRLF
         "                  [-p pid file]" CRLF
         "");
@@ -103,7 +103,7 @@ rct_get_options(int argc, char **argv, struct instance *nci)
 
 	if(argc <= 1)
 	{
-		log_stderr("redis_cluster_tool needs some options.\n");
+		log_stderr("redis-cluster-tool needs some options.\n");
 		return RCT_ERROR;
 	}
 
@@ -133,7 +133,7 @@ rct_get_options(int argc, char **argv, struct instance *nci)
         case 'v':
             value = rct_atoi(optarg);
             if (value < 0) {
-                log_stderr("redis_cluster_tool: option -v requires a number");
+                log_stderr("redis-cluster-tool: option -v requires a number");
                 return RCT_ERROR;
             }
             nci->log_level = value;
@@ -150,7 +150,7 @@ rct_get_options(int argc, char **argv, struct instance *nci)
         case 'i':
             value = rct_atoi(optarg);
             if (value < 0) {
-                log_stderr("redis_cluster_tool: option -i requires a number");
+                log_stderr("redis-cluster-tool: option -i requires a number");
                 return RCT_ERROR;
             }
 
@@ -174,27 +174,27 @@ rct_get_options(int argc, char **argv, struct instance *nci)
             case 'o':
             case 'c':
             case 'p':
-                log_stderr("redis_cluster_tool: option -%c requires a file name",
+                log_stderr("redis-cluster-tool: option -%c requires a file name",
                            optopt);
                 break;
 
             case 'v':
             case 'i':
-                log_stderr("redis_cluster_tool: option -%c requires a number", optopt);
+                log_stderr("redis-cluster-tool: option -%c requires a number", optopt);
                 break;
 
             case 'a':
-                log_stderr("redis_cluster_tool: option -%c requires a string", optopt);
+                log_stderr("redis-cluster-tool: option -%c requires a string", optopt);
                 break;
 
             default:
-                log_stderr("redis_cluster_tool: invalid option -- '%c'", optopt);
+                log_stderr("redis-cluster-tool: invalid option -- '%c'", optopt);
                 break;
             }
             return RCT_ERROR;
 
         default:
-            log_stderr("redis_cluster_tool: invalid option -- '%c'", optopt);
+            log_stderr("redis-cluster-tool: invalid option -- '%c'", optopt);
             return RCT_ERROR;
 
         }


### PR DESCRIPTION
I was just going to update the Readme to match the executable but the help descriptions in the code were also inconsistent. 
